### PR TITLE
Validation tests

### DIFF
--- a/export_to_spec.sh
+++ b/export_to_spec.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Use this script to export/copy the tests in this repo to the spec repo
+# Usage: ./export_to_spec.sh SPEC_REPO_PATH
+
+# A commit we expect to see in the spec repo.
+# Just used as a check to see that the repo path is valid.
+SPEC_REPO_COMMIT="ec38c06717612db984314ceef08878838e1fd9ee"
+
+function error() {
+  echo "Error: $1"
+  exit 1
+}
+
+if [[ $# -ne 1 ]] ; then
+  error "invalid arguments argument. Usage: ./export_to_spec.sh SPEC_REPO_PATH"
+fi
+
+spec_repo_dir=$(readlink -f $1)
+
+
+if [[ ! -d "$spec_repo_dir" ]] ; then
+  echo 123
+fi
+
+pushd "$spec_repo_dir" || error "could not cd to $spec_repo_dir"
+
+git rev-parse --verify "$SPEC_REPO_COMMIT" ||
+    error "Did not find expected commit $SPEC_REPO_COMMIT in $spec_repo_dir. Is it really a spec repo?"
+
+popd
+
+cp spec/validation.wast $spec_repo_dir/test/core/wasmfx_validation.wast
+cp spec/validation_gc.wast $spec_repo_dir/test/core/wasmfx_validation_gc.wast
+
+
+# Let's make sure that our tests actually work
+cd "$spec_repo_dir"/interpreter
+make || error "failed to build reference interpreter"
+make test || error "New tests caused failure?"

--- a/spec/validation.wast
+++ b/spec/validation.wast
@@ -1,0 +1,798 @@
+;; This file tests validation only, without GC types and subtyping.
+
+
+;;;;
+;;;; WasmFX types
+;;;;
+
+(module
+  (type $ft1 (func))
+  (type $ct1 (cont $ft1))
+
+  (type $ft2 (func (param i32) (result i32)))
+  (type $ct2 (cont $ft2))
+
+  (func $test
+    (param $p1 (ref cont))
+    (param $p2 (ref nocont))
+    (param $p3 (ref $ct1))
+
+    (local $x1 (ref cont))
+    (local $x2 (ref nocont))
+    (local $x3 (ref $ct1))
+    (local $x4 (ref $ct2))
+    (local $x5 (ref null $ct1))
+
+    ;; nocont <: cont
+    (local.set $x1 (local.get $p2))
+
+    ;; nocont <: $ct1
+    (local.set $x3 (local.get $p2))
+
+    ;; $ct1 <: $cont
+    (local.set $x3 (local.get $p3))
+
+    ;; (ref $ct1) <: (ref null $cont)
+    (local.set $x5 (local.get $p3))
+   )
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+    (func $test
+      (param $p1 (ref cont))
+      (param $p2 (ref nocont))
+      (param $p3 (ref $ct1))
+
+      (local $x1 (ref cont))
+      (local $x2 (ref nocont))
+      (local $x3 (ref $ct1))
+      (local $x4 (ref $ct2))
+      (local $x5 (ref null $ct1))
+
+      ;; cont </: nocont
+      (local.set $p2 (local.get $p1))
+     )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+    (func $test
+      (param $p1 (ref cont))
+      (param $p2 (ref nocont))
+      (param $p3 (ref $ct1))
+
+      (local $x1 (ref cont))
+      (local $x2 (ref nocont))
+      (local $x3 (ref $ct1))
+      (local $x4 (ref $ct2))
+      (local $x5 (ref null $ct1))
+
+      ;; $ct1 </: nocont
+      (local.set $p2 (local.get $p3))
+     )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+    (func $test
+      (param $p1 (ref cont))
+      (param $p2 (ref nocont))
+      (param $p3 (ref $ct1))
+
+      (local $x1 (ref cont))
+      (local $x2 (ref nocont))
+      (local $x3 (ref $ct1))
+      (local $x4 (ref $ct2))
+      (local $x5 (ref null $ct1))
+
+      ;; $cont </: $ct1
+      (local.set $p3 (local.get $p1))
+     )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+    (func $test
+      (param $p1 (ref cont))
+      (param $p2 (ref nocont))
+      (param $p3 (ref $ct1))
+      (param $p4 (ref $ct2))
+      (param $p5 (ref null $ct1))
+
+
+      (local $x1 (ref cont))
+      (local $x2 (ref nocont))
+      (local $x3 (ref $ct1))
+      (local $x4 (ref $ct2))
+      (local $x5 (ref null $ct1))
+
+      ;; (ref null $ct1) </: (ref $cont)
+      (local.set $x3 (local.get $p5))
+     )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+    (func $test
+      (param $p1 (ref cont))
+      (param $p2 (ref nocont))
+      (param $p3 (ref $ct1))
+      (param $p4 (ref $ct2))
+      (param $p5 (ref null $ct1))
+
+
+      (local $x1 (ref cont))
+      (local $x2 (ref nocont))
+      (local $x3 (ref $ct1))
+      (local $x4 (ref $ct2))
+      (local $x5 (ref null $ct1))
+
+      ;; (ref $ct1) </: (ref $ct2)
+      (local.set $p4 (local.get $p3))
+     )
+  )
+  "type mismatch"
+)
+
+;;;;
+;;;; cont_bind instructions
+;;;;
+
+(module
+  (type $ft0 (func (result i32)))
+  (type $ct0 (cont $ft0))
+
+  (type $ft1 (func (param i32) (result i32)))
+  (type $ct1 (cont $ft1))
+
+  (type $ft2 (func (param i64 i32) (result i32)))
+  (type $ct2 (cont $ft2))
+
+
+  (func $test1
+    (param $p_ct1 (ref null $ct1))
+    (result (ref $ct0))
+
+    ;; cont.bind takes nullable ref, returns non-nullable one
+    (i32.const 123)
+    (local.get $p_ct1)
+    (cont.bind $ct1 $ct0)
+  )
+
+  (func $test2
+    (param $p_ct2 (ref $ct2))
+    (result (ref $ct1))
+
+    ;; cont.bind does not have to apply continuation fully
+    (i64.const 123)
+    (local.get $p_ct2)
+    (cont.bind $ct2 $ct1)
+  )
+
+  (func $test3
+    (param $p_ct1 (ref $ct1))
+    (result (ref $ct1))
+
+    ;; cont.bind can take same type twice, not actually apply anything
+    (local.get $p_ct1)
+    (cont.bind $ct1 $ct1)
+  )
+
+
+ )
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (func $error
+      (param $p_ft0 (ref $ft0))
+      ;; error: non-continuation type on cont.bind
+      (local.get $p_ft0)
+      (cont.bind $ft0 $ft0)
+      (drop)
+    )
+  )
+  "non-continuation type"
+)
+
+  ;; cont.new type mismatch: passing a continuation reference to cont.new instead of function reference
+  ;; This is actually just checking type-matching, not cont.new specific:
+  ;; (ref null $ct1) is not a subtype of (ref null $ft1)
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (func $error
+      (param $p_ct1 (ref $ct1))
+      ;; cont.bind type mismatch: passing wrong kind of continuation.
+      ;; This is actually just checking type-matching, not cont.bind specific.
+      (local.get $p_ct1)
+      (cont.bind $ct0 $ct0)
+      (drop)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i64 i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+
+    (type $ft1_alt (func (param i64) (result i32)))
+    (type $ct1_alt (cont $ft1_alt))
+
+    (func $error
+      (param $p_ct2 (ref $ct2))
+      ;; error: two continuation types not agreeing on arg types
+      (i64.const 123)
+      (local.get $p_ct2)
+      (cont.bind $ct2 $ct1_alt)
+      (drop)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i64 i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+
+    (type $ft1_alt (func (param i32) (result i64)))
+    (type $ct1_alt (cont $ft1_alt))
+
+    (func $error
+      (param $p_ct2 (ref $ct2))
+      ;; error: two continuation types not agreeing on return types
+      (i64.const 123)
+      (local.get $p_ct2)
+      (cont.bind $ct2 $ct1_alt)
+      (drop)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (func $error
+      (param $p_ct0 (ref $ct0))
+      ;; error: trying to go from 0 to 1 args
+      (local.get $p_ct0)
+      (cont.bind $ct0 $ct1)
+      (drop)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+
+    (func $error
+      (param $p_ct1 (ref $ct1))
+      ;; error: Insufficient arguments::
+      ;; This is really testing the general application of arguments to instructions,
+      ;; but trying to trick parsers of the folded form
+      (cont.bind $ct1 $ct0 (local.get $p_ct1))
+      (drop)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+
+  (module
+    (type $ft0 (func (result i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (func $error
+      (param $p_ct1 (ref $ct1))
+      ;; error: Too many arguments::
+      ;; This is really testing the general application of arguments to instructions,
+      ;; but trying to trick parsers of the folded form
+      (cont.bind $ct1 $ct0 (i32.const 123) (i32.const 123) (local.get $p_ct1))
+      (drop)
+    )
+  )
+  "type mismatch"
+)
+
+;;;;
+;;;; cont_new instructions
+;;;;
+
+(module
+  (type $ft1 (func (param i32) (result i32)))
+  (type $ct1 (cont $ft1))
+
+  (type $ft2 (func (param i32 i32) (result i32)))
+  (type $ct2 (cont $ft2))
+
+  (func $f1 (export "f1") (param i32) (result i32)
+    (i32.const 123)
+  )
+
+  (func $drop_ct1 (param $c (ref $ct1)))
+
+  ;; simple smoke test
+  (func $test_good1 (param $x (ref $ft1)) (result (ref $ct1))
+    (local.get $x)
+    (cont.new $ct1)
+  )
+
+  ;; cont.new takes a nullable function
+  (func $test_good2 (param $x (ref null $ft1)) (result (ref $ct1))
+    (local.get $x)
+    (cont.new $ct1)
+  )
+
+
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (func $bad (param $x (ref null $ct1)) (result (ref $ct1))
+      (local.get $x)
+      (cont.new $ct1)
+    )
+  )
+  ;; cont.new type mismatch: passing a continuation reference to cont.new instead of function reference
+  ;; This is actually just checking type-matching, not cont.new specific:
+  ;; (ref null $ct1) is not a subtype of (ref null $ft1)
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (type $ft2 (func (param i32 i32) (result i32)))
+    (type $ct2 (cont $ft2))
+
+    (func $drop_ct1 (param $c (ref $ct1)))
+
+    (func $bad (param $x (ref null $ft2)) (result (ref $ct1))
+      (local.get $x)
+      (cont.new $ct1)
+    )
+  )
+  ;; cont.new type mismatch: passing function of wrong type to cont.new
+  ;; This is actually just checking type-matching, not cont.new specific:
+  ;; (ref null $ft2) is not a subtype of (ref null $ft1)
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft1 (func (param i32) (result i32)))
+    (type $ct1 (cont $ft1))
+
+    (func $bad (param $x (ref null $ct1))
+      (local.get $x)
+      (cont.new $ft1)
+      (drop)
+    )
+  )
+  ;; non-continuation type on cont.new
+  "non-continuation type 0"
+)
+
+;;;;
+;;;; resume instructions
+;;;;
+
+
+(module
+  (type $ft0 (func))
+  (type $ct0 (cont $ft0))
+
+  (type $ft1 (func (param f32) (result f64)))
+  (type $ct1 (cont $ft1))
+
+  (type $ft2 (func (param i64) (result f64)))
+  (type $ct2 (cont $ft2))
+
+  (type $ft3 (func (param i32) (result f64)))
+  (type $ct3 (cont $ft3))
+
+  (tag $t0)
+  (tag $t1)
+  (tag $t2 (param i32) (result i64))
+  (tag $t3 (param i64) (result i32))
+
+  ;; Multiple tags, all types handled correctly
+  (func $test0 (param $x (ref $ct1)) (result f64)
+    (block $handler0 (result i32 (ref $ct2))
+      (block $handler1 (result i64 (ref $ct3))
+        (f32.const 1.23)
+        (local.get $x)
+        (resume $ct1 (on $t2 $handler0) (on $t3 $handler1))
+        (return)
+      )
+      (unreachable)
+    )
+    (unreachable)
+  )
+
+  ;; Same as $test0, but we provide two handlers for the same tag
+  (func $test1 (param $x (ref $ct1)) (result f64)
+    (block $handler0 (result i32 (ref $ct2))
+      (block $handler1 (result i32 (ref $ct2))
+        (f32.const 1.23)
+        (local.get $x)
+        (resume $ct1 (on $t2 $handler0) (on $t2 $handler1))
+        (return)
+      )
+      (unreachable)
+    )
+    (unreachable)
+  )
+
+  ;; resume takes a nullable reference
+  (func $test2 (param $x (ref null $ct0))
+    (local.get $x)
+    (resume $ct0)
+  )
+
+  ;; handler blocks take the continuation as nullable ref
+  (func $test3 (param $x (ref $ct0))
+    (block $handler (result (ref null $ct0))
+      (local.get $x)
+      (resume $ct0 (on $t0 $handler))
+      (return)
+    )
+    (unreachable)
+  )
+
+  ;; Nothing wrong with using the same handler block for multiple tags
+  (func $test4 (param $x (ref $ct0))
+    (block $handler (result (ref null $ct0))
+      (local.get $x)
+      (resume $ct0 (on $t0 $handler) (on $t1 $handler))
+      (return)
+    )
+    (unreachable)
+  )
+
+  ;; handler block can have params
+  (func $test5 (param $x (ref $ct0))
+    (local.get $x)
+    (block $handler (param (ref $ct0)) (result (ref $ct0))
+      (resume $ct0 (on $t0 $handler))
+      (return)
+    )
+    (unreachable)
+  )
+)
+
+;; tag does not exist
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+    ;;(tag $t0)
+    (func $error (param $x (ref $ct0))
+      (block $handler (result (ref null $ct0))
+        (local.get $x)
+        (resume $ct0 (on 0 $handler))
+        (return)
+      )
+      (unreachable)
+    )
+
+  )
+  "unknown tag"
+)
+
+;; non-continuation type on resume
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+    (func $error (param $x (ref $ct0))
+      (local.get $x)
+      (resume $ft0)
+    )
+
+  )
+  "non-continuation type"
+)
+
+;; non-continuation type on handler
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+    (tag $t0)
+    (func $test1 (param $x (ref $ct0))
+      (block $handler (result (ref $ft0))
+        (local.get $x)
+        (resume $ct0 (on $t0 $handler))
+        (return)
+      )
+      (unreachable)
+    )
+
+  )
+  "non-continuation type"
+)
+
+(assert_invalid
+  (module
+    (type $ft (func (param i32)))
+    (type $ct (cont $ft))
+
+    (func $error
+      (param $p (ref $ct))
+      ;; error: Too many arguments::
+      ;; This is really testing the general application of arguments to instructions,
+      ;; but trying to trick parsers of the folded form
+      (resume $ct (i32.const 123) (i32.const 123) (local.get $p))
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft (func (param i32)))
+    (type $ct (cont $ft))
+
+    (func $error
+      (param $p (ref $ct))
+      ;; error: Too few arguments::
+      ;; This is really testing the general application of arguments to instructions,
+      ;; but trying to trick parsers of the folded form
+      (resume $ct (local.get $p))
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft0 (func (param i32)))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i64)))
+    (type $ct1 (cont $ft1))
+
+    (func $error
+      (param $p (ref $ct1))
+      ;; error: Mismatch between annotation on resume and actual argument
+      ;; This is really testing the general application of arguments to instructions.
+      (resume $ct0 (i32.const 123) (local.get $p))
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+
+    (tag $t (param i32))
+
+    (func $error
+      (param $p (ref $ct0))
+      (block $handler (result (ref $ct0))
+        ;; error: handler block has insufficient number of results
+        (local.get $p)
+        (resume $ct0 (on $t $handler))
+        (return)
+      )
+      (unreachable)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+
+    (tag $t (param i32))
+
+    (func $error
+      (param $p (ref $ct0))
+      (block $handler (result i32 i32 (ref $ct0))
+        ;; error: handler block has too many results
+        (local.get $p)
+        (resume $ct0 (on $t $handler))
+        (return)
+      )
+      (unreachable)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+
+    (tag $t (param i32))
+
+    (func $error
+      (param $p (ref $ct0))
+      (block $handler (result i64 (ref $ct0))
+        ;; error: type mismatch in non-continuation handler result type
+        (local.get $p)
+        (resume $ct0 (on $t $handler))
+        (return)
+      )
+      (unreachable)
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+
+    (type $ft1 (func (param i32)))
+    (type $ct1 (cont $ft1))
+
+    (tag $t (param i32))
+
+    (func $error
+      (param $p (ref $ct0))
+      (block $handler (result i32 (ref $ct1))
+        ;; error: type mismatch in continuation handler result type
+        (local.get $p)
+        (resume $ct0 (on $t $handler))
+        (return)
+      )
+      (unreachable)
+    )
+  )
+  "type mismatch"
+)
+
+;;;;
+;;;; suspend instructions
+;;;;
+
+(module
+  (tag $t (param i64 i32) (result i32 i64))
+
+  (func $test (result i32 i64)
+    (i64.const 123)
+    (i32.const 123)
+    (suspend $t)
+  )
+)
+
+
+(assert_invalid
+  (module
+    (tag $t (param i64 i32) (result i32 i64))
+
+    (func $test (result i32 i64)
+      ;; error: Insufficient arguments::
+      ;; This is really testing the general application of arguments to instructions,
+      ;; but trying to trick parsers of the folded form
+
+      (suspend $t (i64.const 123))
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (tag $t (param i32) (result i32 i64))
+
+    (func $test (result i32 i64)
+      ;; error: Too many arguments:
+      ;; This is really testing the general application of arguments to instructions,
+      ;; but trying to trick parsers of the folded form
+
+      (suspend $t (i64.const 123) (i32.const 123))
+    )
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (func $test
+      ;; error: Tag does not exist
+      (suspend 0)
+    )
+  )
+  "unknown tag"
+)

--- a/spec/validation_gc.wast
+++ b/spec/validation_gc.wast
@@ -1,0 +1,320 @@
+;; This file tests validation only, focusing on GC types and subtyping.
+
+;;;;
+;;;;; WasmFX types
+;;;;
+
+
+(module
+  (type $f (func))
+
+  (type $ft1 (sub (func (param (ref $f)) (result (ref func)))))
+  (type $ct1 (sub (cont $ft1)))
+
+  (type $ft2 (func (param (ref any)) (result (ref func))))
+  (type $ct2 (cont $ft2))
+
+  (type $ft3 (sub $ft1 (func (param (ref func)) (result (ref $f)))))
+  (type $ct3 (cont $ft3))
+
+  ;; Okay: Continuation types are covariant, have declared $ft3 <: $ft1
+  (type $ct_sub (sub $ct1 (cont $ft3)))
+
+  (func $test
+    (param $p1 (ref $ct1))
+    (param $p2 (ref $ct_sub))
+
+    ;; Okay: (ref $ct_sub) <: (ref $ct1)
+    (local.set $p1 (local.get $p2))
+
+  )
+
+)
+
+(assert_invalid
+  (module
+    (type $f (func))
+
+    (type $ft1 (sub (func (param (ref $f)) (result (ref func)))))
+    (type $ct1 (sub (cont $ft1)))
+
+    (type $ft2 (func (param (ref func)) (result (ref $f))))
+
+    ;; Error: $ft2 and ft1 have compatible types, but have not declared $ft2 <: ft1
+    (type $error (sub $ct1 (cont $ft2)))
+
+  )
+  "sub type 4 does not match super type 2"
+)
+
+(assert_invalid
+  (module
+    (type $f (func))
+
+    (type $ft1 (sub (func (param (ref $f)) (result (ref func)))))
+    (type $ct1 (sub (cont $ft1)))
+
+    (type $ft2 (func (param (ref func)) (result (ref $f))))
+    (type $ct2 (cont $ft2))
+
+   (func $test
+    (param $p1 (ref $ct1))
+    (param $p2 (ref $ct2))
+
+    ;; Error $ct2 and $ct1 have generally compatible types,
+    ;; but have not declared $ft2 <: ft1 or $ct2 <: $ct1
+    ;; Thus, $ct2 </: $ct1.
+    (local.set $p1 (local.get $p2))
+
+  )
+
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+    (type $f (func))
+
+    (type $ft1 (sub (func (param (ref $f)) (result (ref func)))))
+    (type $ct1 (sub (cont $ft1)))
+    (type $ft3 (sub $ft1 (func (param (ref func)) (result (ref $f)))))
+    (type $ct3 (cont $ft3))
+
+   (func $error
+    (param $p1 (ref $ct1))
+    ;;(param $p2 (ref $ct2))
+    (param $p3 (ref $ct3))
+
+    ;; Error $ct3 and $ct1 have generally compatible types,
+    ;; (in particular: declared $ft3 <: ft1,
+    ;; but have not declared $ct3 <: $ct1
+    ;; $ct3 </: $ct1
+    (local.set $p1 (local.get $p3))
+
+  )
+
+  )
+  "type mismatch"
+)
+
+(assert_invalid
+  (module
+
+    (func $error
+      (param $p_any (ref any))
+      (param $p_cont (ref cont))
+
+      ;; Error: cont </: any
+      (local.set $p_any (local.get $p_cont))
+    )
+  )
+
+  "type mismatch"
+)
+
+;;;;
+;;;; cont_bind instructions
+;;;;
+
+(module $non_final
+
+  (type $ft1 (func (param i32) (result (ref func))))
+  (type $ct1 (sub (cont $ft1)))
+
+  (type $ft0 (func (result (ref func))))
+  (type $ct0 (sub (cont $ft0)))
+
+  (func $test1 (param $x (ref $ct1))
+    (i32.const 123)
+    (local.get $x)
+    ;; Smoke test: using non-final types here
+    (cont.bind $ct1 $ct0)
+    (drop)
+  )
+)
+
+
+(module $subtyping0
+
+  (type $f (func))
+
+  (type $ft0_sup (func (result (ref func))))
+  (type $ct0_sup (cont $ft0_sup))
+
+  (type $ft1 (func (param i32) (result (ref $f))))
+  (type $ct1 (cont $ft1))
+
+  (type $ft0 (func (result (ref $f))))
+  (type $ct0 (cont $ft0))
+
+
+  (func $test2 (param $x (ref $ct1))
+    (i32.const 123)
+    (local.get $x)
+    ;; Okay: The most natural second continuation type would be $ct0.
+    ;; But we have (func (result (ref $f))) <: (func (result (ref $func)))
+    ;; This holds without us needing to declare any subtyping relations at all.
+    (cont.bind $ct1 $ct0_sup)
+    (drop)
+  )
+
+)
+
+(module $recursive
+
+  (rec
+    (type $ft0 (func             (result (ref $ct_rec))))
+    (type $ft1 (func (param i32) (result (ref $ct_rec))))
+    (type $ct_rec (cont $ft1))
+  )
+  (type $ct0 (cont $ft0))
+
+  (rec
+    (type $ft0' (func             (result (ref $ct_rec'))))
+    (type $ft1' (func (param i32) (result (ref $ct_rec'))))
+    (type $ct_rec' (cont $ft1'))
+  )
+  (type $ct1 (cont $ft1'))
+
+
+  ;; Okay: Some simple test where the types involved in cont.bind
+  ;; are part of a recursion group
+  ;; (more concretely: two equivalent recursion groups)
+  (func $test (param $x (ref $ct1))
+    (i32.const 123)
+    (local.get $x)
+    (cont.bind $ct1 $ct0)
+    (drop)
+  )
+
+)
+
+(module $recursive_subtyping
+
+  ;; We define types such that $ft0 <: $ft0_sup and $ct_rec <: $ct_rec_sup
+  (rec
+    (type $ft0_sup (sub          (func             (result (ref $ct_rec_sup)))))
+    (type $ft0     (sub $ft0_sup (func             (result (ref $ct_rec)))))
+    (type $ft1     (sub          (func (param i32) (result (ref $ct_rec)))))
+
+    (type $ct_rec_sup (sub (cont $ft0_sup)))
+    (type $ct_rec     (sub $ct_rec_sup (cont $ft0)))
+  )
+
+  (type $ct0_sup (cont $ft0_sup))
+  (type $ct0     (cont $ft0))
+  (type $ct1     (cont $ft1))
+
+
+  (func $test (param $x (ref $ct1))
+    (i32.const 123)
+    (local.get $x)
+    (cont.bind $ct1 $ct0)
+    (drop)
+
+    (i32.const 123)
+    (local.get $x)
+    ;; Okay: We have (func (result (ref $ct_rec))) <: (func (result (ref
+    ;; $ct_rec_sup)))
+    (cont.bind $ct1 $ct0_sup)
+    (drop)
+  )
+
+)
+
+;;;;
+;;;; resume instructions
+;;;;
+
+
+(module $subtyping-resume0
+
+  (type $ft0 (func))
+  (type $ct0 (cont $ft0))
+
+  (type $ft_sup (func (param (ref $ft0))))
+  (type $ct_sup (cont $ft_sup))
+
+  (type $ft_sub (func (param (ref func))))
+  (type $ct_sub (cont $ft_sub)) ;; unused
+
+  (tag $t (result (ref func)))
+
+  (func $test0
+    (param $p (ref $ct0))
+
+    ;; Here we test subtyping with respect to the continuations received by handlers.
+    ;;
+    ;; The most "straightforward" type of the continuation in $handler would be (ref
+    ;; $ct_sub). Instead, we use $ct_sup. According to the spec, we neither need
+    ;; to declare $ft_sub <: $ft_sup or $ct_sub <: $ct_sup for this to work. We
+    ;; have (func (param (ref func))) <: (func (param (ref $ft0))), which is
+    ;; sufficient
+    (block $handler (result (ref $ct_sup))
+      (local.get $p)
+      (resume $ct0 (on $t $handler))
+      (return)
+    )
+    (unreachable)
+  )
+)
+
+(module $subtyping-resume1
+
+  (type $ft0 (func))
+  (type $ct0 (cont $ft0))
+
+  (tag $t (param (ref $ft0)))
+
+  (func $test0
+    (param $p (ref $ct0))
+
+    ;; Here we test subtyping with respect to the payloads received by handlers.
+    ;; Instead of just (ref $ft0), then handler takes func.
+    (block $handler (result (ref func) (ref $ct0))
+      (local.get $p)
+      (resume $ct0 (on $t $handler))
+      (return)
+    )
+    (unreachable)
+  )
+
+)
+
+(assert_invalid
+  (module
+
+    (type $ft0 (func))
+    (type $ct0 (cont $ft0))
+
+    (type $ft_sup (sub (func (param (ref $ft0)))))
+    (type $ct_sup (sub (cont $ft_sup)))
+
+    (type $ft_sub (sub $ft_sup (func (param (ref func)))))
+    (type $ct_sub (cont $ft_sub))
+
+    (tag $t (param (ref $ct_sub)))
+
+    (func $test0
+      (param $p (ref $ct0))
+
+      ;; This is similar to $subtyping1, but this time we use a continuation as payload.
+      ;; But we did not actually declare $ct_sub <: $ct_sub.
+      ;;
+      ;; This is mostly just to check the following:
+      ;; For the continuation received by every handler, we see through the
+      ;; continuation type and do structural subtyping on the underlying
+      ;; function type.
+      ;; However, for continuations that are just payloads ($ct_sup here), we do
+      ;; ordinary nominal subtyping.
+      (block $handler (result (ref $ct_sup) (ref $ct0))
+        (local.get $p)
+        (resume $ct0 (on $t $handler))
+        (return)
+      )
+      (unreachable)
+    )
+  )
+  "type mismatch"
+)


### PR DESCRIPTION
This PR adds a series of tests that should cover every aspect of validating WasmFX instructions and types, except for `resume_throw` and `barrier`.

Since the GC proposal has technically not landed yet, I've moved those tests for the interaction with GC types and subtyping into their own file.

This PR also includes a bash script for moving these tests into an appropriate subfolder of a given `spec` repo.